### PR TITLE
feat(game): polish game page (How To Play modal, typewriter tips, single column)

### DIFF
--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -36,14 +36,8 @@ import {
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { LoaderOverlay } from "@/components/loader-overlay";
+import { RotatingTip } from "@/components/rotating-tip";
 import { POKEMON_CONSTANTS } from "@/constants/pokemon";
 import { CollapsibleSidebar } from "@/components/collapsible-sidebar";
 import { Footer } from "@/components/footer";
@@ -53,8 +47,8 @@ import {
   Lightbulb,
   Flag,
   Sparkles,
-  Search,
   Calendar,
+  HelpCircle,
   Infinity as InfinityIcon,
   Users,
 } from "lucide-react";
@@ -64,6 +58,8 @@ import { AnimatedDotGrid } from "@/components/animated-dot-grid";
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -252,8 +248,12 @@ export default function GamePage() {
   const [revealedHints, setRevealedHints] = useState<number[]>([]);
   const [hintCooldown, setHintCooldown] = useState(0); // Cooldown in seconds (0-5)
   const [showGameResultDialog, setShowGameResultDialog] = useState(false);
-  const [showSearchDialog, setShowSearchDialog] = useState(false);
   const [showGiveUpDialog, setShowGiveUpDialog] = useState(false);
+  // The "How to Play" modal opens automatically on a player's first
+  // visit and can be re-opened any time via the help icon button. We
+  // persist a single boolean marker in localStorage so we don't pester
+  // returning players. See `HOW_TO_PLAY_STORAGE_KEY` below.
+  const [showHowToPlayDialog, setShowHowToPlayDialog] = useState(false);
   const hintRefs = useRef<(HTMLDivElement | null)[]>([]);
   const guessRefs = useRef<(HTMLDivElement | null)[]>([]);
   const colorBarRef = useRef<HTMLDivElement | null>(null);
@@ -264,6 +264,7 @@ export default function GamePage() {
   const MAX_ATTEMPTS = 4;
 
   const PENDING_ATTEMPTS_KEY = "pokemon-palette-pending-attempts";
+  const HOW_TO_PLAY_STORAGE_KEY = "pokemon-palette-game-tutorial-seen";
 
   // Alias the shared helper locally so the existing getTextColor(...) call
   // sites don't all need to churn. The real implementation lives in
@@ -308,6 +309,42 @@ export default function GamePage() {
       setCheckingAuth(true);
     }
   }, [mode]);
+
+  // Auto-open the How to Play modal on a player's first visit. We default
+  // the state to closed so SSR markup matches the client first paint;
+  // only after mount do we read localStorage and possibly flip it open.
+  // The marker isn't written here — we wait until the player explicitly
+  // dismisses the modal so a quick refresh still shows it once.
+  // Multiplayer mode renders its own component flow, so skip there.
+  useEffect(() => {
+    if (mode === "multiplayer") return;
+    try {
+      const seen =
+        typeof window !== "undefined"
+          ? window.localStorage.getItem(HOW_TO_PLAY_STORAGE_KEY)
+          : "true";
+      if (!seen) {
+        setShowHowToPlayDialog(true);
+      }
+    } catch {
+      // localStorage may be unavailable (private mode, etc.). Fail
+      // silently — the help button is still always available.
+    }
+    // Intentionally run once on mount. Subsequent mode changes shouldn't
+    // re-trigger the auto-open; the help button covers that case.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleHowToPlayOpenChange = (open: boolean) => {
+    setShowHowToPlayDialog(open);
+    if (!open) {
+      try {
+        window.localStorage.setItem(HOW_TO_PLAY_STORAGE_KEY, "true");
+      } catch {
+        // ignore storage failures
+      }
+    }
+  };
 
   // Check if user has already played today's daily game
   useEffect(() => {
@@ -1416,11 +1453,6 @@ export default function GamePage() {
     }
   };
 
-  const handleGuessWithDialog = (pokemonId: number) => {
-    handleGuess(pokemonId);
-    setShowSearchDialog(false);
-  };
-
   const resetGame = async () => {
     // Don't allow reset for daily mode if already completed
     if (mode === "daily" && status !== "playing") {
@@ -1978,12 +2010,38 @@ export default function GamePage() {
                     )}
                   </div>
                   <div className="flex items-center gap-2">
+                    {/* Re-opens the How to Play modal. Lives in the
+                        action row alongside the other game-context
+                        actions so first-time players (and people who
+                        forget the rules) have a consistent place to
+                        find it. */}
+                    <Button
+                      onClick={() => setShowHowToPlayDialog(true)}
+                      variant="outline"
+                      size="icon"
+                      aria-label="How to play"
+                      className="cursor-pointer"
+                    >
+                      <HelpCircle className="w-4 h-4" />
+                    </Button>
                     {/* Daily mode: leaderboard lives behind a button now
                         rather than as an inline section at the bottom of
                         the page. Same row as Give Up so it sits with the
                         other game-context actions instead of being
-                        below-the-fold scroll content. */}
-                    {mode === "daily" && <GameLeaderboardDialog />}
+                        below-the-fold scroll content.
+
+                        Gated on `status !== "playing"` so the button only
+                        appears once today's daily run is finished
+                        (won/lost/given-up). Mid-game visitors — including
+                        returning players who haven't completed today —
+                        shouldn't see leaderboard standings before they've
+                        played. `checkTodayAttempt` already restores
+                        previously-completed runs to "won"/"lost", and the
+                        signed-out localStorage path (PENDING_ATTEMPTS_KEY)
+                        does the same, so this gate works for both. */}
+                    {mode === "daily" && status !== "playing" && (
+                      <GameLeaderboardDialog />
+                    )}
                     {mode === "unlimited" && (
                       <Button
                         onClick={resetGame}
@@ -2003,6 +2061,66 @@ export default function GamePage() {
                 </div>
               </div>
             </div>
+          )}
+
+          {/* How to Play Dialog. Auto-opens once for first-time
+              players (see the mount effect that reads localStorage)
+              and is also reachable any time via the help icon button
+              in the action row above. */}
+          {mode !== "multiplayer" && (
+            <Dialog
+              open={showHowToPlayDialog}
+              onOpenChange={handleHowToPlayOpenChange}
+            >
+              <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                  <DialogTitle className="text-lg flex items-center gap-2">
+                    <Sparkles className="w-4 h-4" />
+                    How to Play
+                  </DialogTitle>
+                  <DialogDescription>
+                    Guess the Pokemon based on its color palette
+                  </DialogDescription>
+                </DialogHeader>
+                <ul className="space-y-2 text-sm">
+                  <li className="flex items-start gap-2">
+                    <span className="text-muted-foreground mt-0.5">•</span>
+                    <span>
+                      You have <strong>{MAX_ATTEMPTS} attempts</strong> to
+                      guess the correct Pokemon
+                    </span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="text-muted-foreground mt-0.5">•</span>
+                    <span>
+                      Use the color palette at the top to identify the Pokemon
+                    </span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="text-muted-foreground mt-0.5">•</span>
+                    <span>
+                      After each guess, you&apos;ll see how similar your guess
+                      is to the target
+                    </span>
+                  </li>
+                  <li className="flex items-start gap-2">
+                    <span className="text-muted-foreground mt-0.5">•</span>
+                    <span>
+                      Use hints to narrow down your options (up to 3 hints
+                      available)
+                    </span>
+                  </li>
+                </ul>
+                <DialogFooter>
+                  <Button
+                    onClick={() => handleHowToPlayOpenChange(false)}
+                    className="w-full sm:w-auto cursor-pointer"
+                  >
+                    Got it
+                  </Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
           )}
 
           {/* Game Status Dialog (daily/unlimited only) */}
@@ -2033,304 +2151,83 @@ export default function GamePage() {
             />
           )}
 
-          {/* Two Column Layout: Search (Left) and Guesses (Right) - 50/50 Split (daily/unlimited only) */}
-          {mode !== "multiplayer" && <div className="mb-6 w-full max-w-6xl grid grid-cols-1 lg:grid-cols-2 gap-6">
-            {/* Left Column: Search */}
-            <div className="lg:col-span-1">
-              <div className="space-y-3 p-4 md:p-6">
-                {status === "playing" ? (
-                  <>
-                    {/* Desktop: Show search directly */}
-                    <div className="hidden lg:block">
-                      <PokemonSearch
-                        pokemonList={allPokemonList}
-                        selectedPokemon={null}
-                        onPokemonSelect={handleGuess}
-                        isShiny={isShiny === true}
-                        guessedPokemonIds={guesses.map((g) => g.pokemonId)}
-                        selectedGenerations={
-                          mode === "unlimited"
-                            ? unlimitedSettings.selectedGenerations
-                            : undefined
-                        }
-                        placeholder="Enter Pokemon name or number..."
-                      />
-                      <p className="text-xs text-muted-foreground mt-2 text-center">
-                        💡 Tip: Search works in multiple languages (日本語,
-                        Français, Deutsch, Español, and more!)
-                      </p>
-                    </div>
-                    {/* Mobile: Show button to open dialog */}
-                    <div className="lg:hidden">
-                      <Button
-                        onClick={() => setShowSearchDialog(true)}
-                        className="w-full cursor-pointer"
-                        variant="outline"
-                      >
-                        <Search className="w-4 h-4 mr-2" />
-                        Search Pokemon
-                      </Button>
-                      <Dialog
-                        open={showSearchDialog}
-                        onOpenChange={setShowSearchDialog}
-                      >
-                        <DialogContent className="max-w-[calc(100vw-2rem)] sm:max-w-lg">
-                          <DialogHeader>
-                            <DialogTitle>Search Pokemon</DialogTitle>
-                          </DialogHeader>
-                          <div className="mt-4">
-                            <PokemonSearch
-                              pokemonList={allPokemonList}
-                              selectedPokemon={null}
-                              onPokemonSelect={handleGuessWithDialog}
-                              isShiny={isShiny === true}
-                              guessedPokemonIds={guesses.map(
-                                (g) => g.pokemonId
-                              )}
-                              selectedGenerations={
-                                mode === "unlimited"
-                                  ? unlimitedSettings.selectedGenerations
-                                  : undefined
-                              }
-                              placeholder="Enter Pokemon name or number..."
-                            />
-                            <p className="text-xs text-muted-foreground mt-2 text-center">
-                              💡 Tip: Search works in multiple languages
-                              (日本語, Français, Deutsch, Español, and more!)
-                            </p>
-                          </div>
-                        </DialogContent>
-                      </Dialog>
-                    </div>
+          {/* Single full-width column: search + tip on top, guesses below.
+              We dropped the old `lg:grid-cols-2` split (and the mobile-only
+              "Search Pokemon" dialog that worked around the cramped narrow
+              column) in favor of a vertical flex stack — guess cards now
+              breathe at every breakpoint and the search is always inline. */}
+          {mode !== "multiplayer" && <div className="mb-6 w-full max-w-xl flex flex-col gap-6">
+            <div className="space-y-3 p-4 md:p-6">
+              {status === "playing" && (
+                <>
+                  <PokemonSearch
+                    pokemonList={allPokemonList}
+                    selectedPokemon={null}
+                    onPokemonSelect={handleGuess}
+                    isShiny={isShiny === true}
+                    guessedPokemonIds={guesses.map((g) => g.pokemonId)}
+                    selectedGenerations={
+                      mode === "unlimited"
+                        ? unlimitedSettings.selectedGenerations
+                        : undefined
+                    }
+                    placeholder="Enter Pokemon name or number..."
+                  />
+                  <RotatingTip />
 
-                    {loadingGuess && (
-                      <p className="text-sm text-muted-foreground mt-2">
-                        Analyzing guess...
-                      </p>
-                    )}
-                  </>
-                ) : (
-                  <div className="flex flex-col justify-center min-h-[400px] rounded-lg border bg-card">
-                    <div className="space-y-4 px-4">
-                      <p className="text-sm text-muted-foreground text-center">
-                        Want to keep playing? Try unlimited mode with random
-                        Pokemon!
-                      </p>
-                      <Button
-                        onClick={async () => {
-                          // Reset all game state first
-                          setGuesses([]);
-                          setAttempts(0);
-                          setStatus("playing");
-                          setRevealedHints([]);
-                          setHintCooldown(0);
-                          setTargetPokemon(null);
-                          setTargetPokemonId(null);
-                          setTargetColors([]);
-                          setAllTargetColors([]);
-                          generatedHintsRef.current = [];
-                          // Switch to unlimited mode
-                          setMode("unlimited");
-                          // Initialize new game in unlimited mode
-                          setLoading(true);
-
-                          // Determine shiny status for unlimited mode
-                          let gameShiny: boolean;
-                          if (unlimitedSettings.shinyPreference === "shiny") {
-                            gameShiny = true;
-                          } else if (
-                            unlimitedSettings.shinyPreference === "normal"
-                          ) {
-                            gameShiny = false;
-                          } else {
-                            gameShiny = getRandomShiny();
-                          }
-                          setIsShiny(gameShiny);
-
-                          // Get filtered Pokemon list for unlimited mode
-                          const filteredPokemonList = allPokemonList.filter(
-                            (p) => {
-                              const generation = getGenerationFromId(p.id);
-                              return unlimitedSettings.selectedGenerations.includes(
-                                generation
-                              );
-                            }
-                          );
-
-                          // Choose random Pokemon
-                          let pokemonId: number;
-                          if (filteredPokemonList.length === 0) {
-                            const randomIndex = Math.floor(
-                              Math.random() * allPokemonList.length
-                            );
-                            pokemonId = allPokemonList[randomIndex].id;
-                          } else {
-                            const randomIndex = Math.floor(
-                              Math.random() * filteredPokemonList.length
-                            );
-                            pokemonId = filteredPokemonList[randomIndex].id;
-                          }
-
-                          setTargetPokemonId(pokemonId);
-                          const pokemonData = await getPokemonById(pokemonId);
-
-                          if (pokemonData) {
-                            setTargetPokemon(pokemonData);
-                            const spriteUrl = getSpriteUrl(
-                              pokemonData,
-                              gameShiny
-                            );
-                            if (spriteUrl) {
-                              try {
-                                const colors = (await extractColorsFromImage(
-                                  spriteUrl,
-                                  POKEMON_CONSTANTS.COLORS_TO_EXTRACT,
-                                  true
-                                )) as ColorWithFrequency[];
-                                setAllTargetColors(colors); // Store all colors
-                                const topColors = colors.slice(
-                                  0,
-                                  POKEMON_CONSTANTS.PALETTE_COLORS_COUNT
-                                );
-                                setTargetColors(topColors);
-                              } catch (error) {
-                                console.error(
-                                  "Failed to extract colors:",
-                                  error
-                                );
-                                const allFallbackColors =
-                                  pokemonData.colorPalette?.highlights || [];
-                                const allFallbackWithFreq: ColorWithFrequency[] =
-                                  allFallbackColors.map((hex, idx) => ({
-                                    hex,
-                                    frequency: 100 - idx * 10,
-                                    percentage:
-                                      ((100 - idx * 10) /
-                                        allFallbackColors.length) *
-                                      100,
-                                  }));
-                                setAllTargetColors(allFallbackWithFreq); // Store all colors
-                                const fallbackColors =
-                                  allFallbackWithFreq.slice(
-                                    0,
-                                    POKEMON_CONSTANTS.PALETTE_COLORS_COUNT
-                                  );
-                                setTargetColors(fallbackColors);
-                              }
-                            }
-                          }
-                          setLoading(false);
-                        }}
-                        className="w-full cursor-pointer"
-                      >
-                        <InfinityIcon className="w-4 h-4 mr-2" />
-                        Play Unlimited Mode
-                      </Button>
-                    </div>
-                  </div>
-                )}
-
-                {/* Game Rules Panel - Show when playing or game hasn't started, hide when game has ended */}
-                {status !== "won" && status !== "lost" && (
-                  <Card className="mt-4">
-                    <CardHeader>
-                      <CardTitle className="text-lg flex items-center gap-2">
-                        <Sparkles className="w-4 h-4" />
-                        How to Play
-                      </CardTitle>
-                      <CardDescription>
-                        Guess the Pokemon based on its color palette
-                      </CardDescription>
-                    </CardHeader>
-                    <CardContent>
-                      <ul className="space-y-2 text-sm">
-                        <li className="flex items-start gap-2">
-                          <span className="text-muted-foreground mt-0.5">
-                            •
-                          </span>
-                          <span>
-                            You have <strong>{MAX_ATTEMPTS} attempts</strong> to
-                            guess the correct Pokemon
-                          </span>
-                        </li>
-                        <li className="flex items-start gap-2">
-                          <span className="text-muted-foreground mt-0.5">
-                            •
-                          </span>
-                          <span>
-                            Use the color palette at the top to identify the
-                            Pokemon
-                          </span>
-                        </li>
-                        <li className="flex items-start gap-2">
-                          <span className="text-muted-foreground mt-0.5">
-                            •
-                          </span>
-                          <span>
-                            After each guess, you&apos;ll see how similar your
-                            guess is to the target
-                          </span>
-                        </li>
-                        <li className="flex items-start gap-2">
-                          <span className="text-muted-foreground mt-0.5">
-                            •
-                          </span>
-                          <span>
-                            Use hints to narrow down your options (up to 3 hints
-                            available)
-                          </span>
-                        </li>
-                      </ul>
-                    </CardContent>
-                  </Card>
-                )}
-              </div>
+                  {loadingGuess && (
+                    <p className="text-sm text-muted-foreground mt-2">
+                      Analyzing guess...
+                    </p>
+                  )}
+                </>
+              )}
             </div>
 
-            {/* Right Column: Previous Guesses */}
-            <div className="lg:col-span-1">
-              <div className="space-y-3 p-4 md:p-6">
-                <div className="flex flex-col gap-3 max-h-[600px] overflow-y-auto">
-                  {Array.from({ length: MAX_ATTEMPTS }).map((_, index) => {
-                    const guess = guesses[index];
-                    const isCorrect =
-                      guess && guess.pokemonId === targetPokemonId;
-                    return guess ? (
-                      <GuessCard
-                        key={index}
-                        guess={guess}
-                        index={index}
-                        isCorrect={isCorrect || false}
-                        onRef={(el) => {
-                          guessRefs.current[index] = el;
-                        }}
-                      />
-                    ) : (
-                      <div
-                        key={index}
-                        ref={(el) => {
-                          guessRefs.current[index] = el;
-                        }}
-                        className="flex items-stretch rounded-lg border bg-card/50 opacity-50 flex-shrink-0 overflow-hidden"
-                      >
-                        <div className="flex-1 min-w-0 flex items-center gap-4 p-3">
-                          {/* Empty placeholder - Image */}
-                          <div className="relative flex-shrink-0 w-16 h-16 bg-muted rounded" />
+            {/* Guesses list — at most MAX_ATTEMPTS (4) cards, so we let
+                them stack naturally without a max-height/scroll cap. */}
+            <div className="space-y-3 px-4 md:px-6">
+              <div className="flex flex-col gap-3">
+                {Array.from({ length: MAX_ATTEMPTS }).map((_, index) => {
+                  const guess = guesses[index];
+                  const isCorrect =
+                    guess && guess.pokemonId === targetPokemonId;
+                  return guess ? (
+                    <GuessCard
+                      key={index}
+                      guess={guess}
+                      index={index}
+                      isCorrect={isCorrect || false}
+                      onRef={(el) => {
+                        guessRefs.current[index] = el;
+                      }}
+                    />
+                  ) : (
+                    <div
+                      key={index}
+                      ref={(el) => {
+                        guessRefs.current[index] = el;
+                      }}
+                      className="flex items-stretch rounded-lg border bg-card/50 opacity-50 flex-shrink-0 overflow-hidden"
+                    >
+                      <div className="flex-1 min-w-0 flex items-center gap-4 p-3">
+                        {/* Empty placeholder - Image */}
+                        <div className="relative flex-shrink-0 w-16 h-16 bg-muted rounded" />
 
-                          {/* Empty placeholder - Name and Match */}
-                          <div className="flex-1 min-w-0">
-                            <div className="h-4 bg-muted rounded mb-2 w-24" />
-                            <div className="h-3 bg-muted rounded w-16" />
-                          </div>
+                        {/* Empty placeholder - Name and Match */}
+                        <div className="flex-1 min-w-0">
+                          <div className="h-4 bg-muted rounded mb-2 w-24" />
+                          <div className="h-3 bg-muted rounded w-16" />
                         </div>
-
-                        {/* Empty placeholder - Colors: matches the flush-right
-                            swatch column used in filled guess cards. */}
-                        <div className="flex-shrink-0 w-10 self-stretch bg-muted" />
                       </div>
-                    );
-                  })}
-                </div>
+
+                      {/* Empty placeholder - Colors: width matches the
+                          filled GuessCard swatch column so empty + filled
+                          slots line up at the new full-width layout. */}
+                      <div className="flex-shrink-0 w-16 self-stretch bg-muted" />
+                    </div>
+                  );
+                })}
               </div>
             </div>
           </div>}

--- a/src/components/guess-card.tsx
+++ b/src/components/guess-card.tsx
@@ -96,8 +96,9 @@ export function GuessCard({ guess, isCorrect = false, onRef }: GuessCardProps) {
 
       {/* Swatch column — flush to the card's top, bottom, and right edges so
           it reads as one continuous stripe (mirrors the big target palette
-          bar at the top of the page). */}
-      <div className="flex-shrink-0 flex flex-col w-10 self-stretch">
+          bar at the top of the page). Width is sized to read as a real
+          color band at the page's full-width layout. */}
+      <div className="flex-shrink-0 flex flex-col w-16 self-stretch">
         {guess.colors.map((color, colorIndex) => (
           <div
             key={colorIndex}

--- a/src/components/rotating-tip.tsx
+++ b/src/components/rotating-tip.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+// Curated list of microcopy tips. Phrased second-person, concise, with
+// curly typography (', …) so they read as polished UI strings rather
+// than raw ASCII. Used only on the game page for now.
+const TIPS = [
+  "Search works in multiple languages (日本語, Français, Deutsch, Español, and more!)",
+  "You can guess by Pokédex number too — try \u201825\u2019 for Pikachu.",
+  "Hints get better the more you guess — try a same-type Pok\u00e9mon first.",
+  "Stuck? The Pok\u00e9mon\u2019s color palette is your biggest clue. Match the dominant tones.",
+  "Use the Filters button to narrow Unlimited mode to specific generations.",
+  "Press Esc to close any dialog.",
+] as const;
+
+// Pacing knobs. The hold time is how long the fully-typed tip stays
+// on screen before we start erasing. The per-char base + jitter is what
+// gives the typing its slightly-organic feel. We cap the *total* typing
+// time so very long tips don't stall the rotation: if a tip would take
+// longer than `MAX_TYPE_TOTAL_MS` at the base pace, we scale the
+// per-char delay down so any tip finishes in roughly that budget.
+const HOLD_MS = 5000;
+const TYPE_PER_CHAR_MS = 30;
+const TYPE_JITTER_MS = 10;
+const MIN_CHAR_DELAY_MS = 8;
+const MAX_TYPE_TOTAL_MS = 2500;
+const ERASE_PER_CHAR_MS = 17;
+
+type Phase = "typing" | "holding" | "erasing";
+
+interface RotatingTipProps {
+  className?: string;
+}
+
+/**
+ * A small marquee that cycles through `TIPS` with a typewriter effect.
+ *
+ * - Renders deterministically on the server (always `TIPS[0]`, no caret
+ *   blink) so the SSR markup is stable; the random starting index, the
+ *   reduced-motion preference, and the typing loop are all set up
+ *   client-side in a `useEffect`.
+ * - Honors `prefers-reduced-motion: reduce`: skips the typewriter
+ *   animation entirely (full text in place, swap on rotation) and
+ *   freezes the caret as a static visible character so the
+ *   `step-end` blink doesn't flash for users who opted out.
+ * - Pauses the typing/erasing/holding timers when the document is
+ *   hidden so background tabs don't tick.
+ * - Screen-reader experience: the visible text region is
+ *   `aria-hidden` (so SRs don't read each character as it types) and
+ *   a separate `sr-only` `aria-live="polite"` region carries the
+ *   *full* tip text. We update that region only when a new tip
+ *   starts, so each rotation is announced once as a complete line.
+ */
+export function RotatingTip({ className }: RotatingTipProps) {
+  const [displayText, setDisplayText] = useState<string>(TIPS[0]);
+  const [announcedTip, setAnnouncedTip] = useState<string>(TIPS[0]);
+  const [reducedMotion, setReducedMotion] = useState(false);
+  const [mounted, setMounted] = useState(false);
+
+  // The state machine drives via refs so the loop doesn't re-create on
+  // every `setDisplayText` call. `phaseRef` is the source of truth for
+  // which step the loop is in; `charPosRef` is the cursor position
+  // inside the current tip; `indexRef` mirrors the active TIPS slot.
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const indexRef = useRef<number>(0);
+  const charPosRef = useRef<number>(TIPS[0].length);
+  const phaseRef = useRef<Phase>("holding");
+  const visibleRef = useRef<boolean>(true);
+
+  // Mount-only side effects: pick a random starting tip and sync to
+  // the user's reduced-motion preference. Doing this on mount (rather
+  // than at module load) keeps SSR markup deterministic.
+  useEffect(() => {
+    const startIndex = Math.floor(Math.random() * TIPS.length);
+    indexRef.current = startIndex;
+    charPosRef.current = TIPS[startIndex].length;
+    phaseRef.current = "holding";
+    setDisplayText(TIPS[startIndex]);
+    setAnnouncedTip(TIPS[startIndex]);
+
+    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setReducedMotion(mql.matches);
+    const onChange = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
+    mql.addEventListener("change", onChange);
+
+    setMounted(true);
+    return () => {
+      mql.removeEventListener("change", onChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+
+    const clear = () => {
+      if (timeoutRef.current !== null) {
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+    };
+
+    const schedule = (ms: number, fn: () => void) => {
+      clear();
+      timeoutRef.current = setTimeout(fn, ms);
+    };
+
+    // Move to the next tip and push the *full* string into the
+    // announcement region so screen readers read the new tip once,
+    // not character-by-character.
+    const advanceTip = () => {
+      const next = (indexRef.current + 1) % TIPS.length;
+      indexRef.current = next;
+      setAnnouncedTip(TIPS[next]);
+    };
+
+    const tick = () => {
+      if (!visibleRef.current) return;
+
+      // Reduced-motion path: full-text swap, no typing, no erasing.
+      if (reducedMotion) {
+        const tip = TIPS[indexRef.current];
+        charPosRef.current = tip.length;
+        phaseRef.current = "holding";
+        setDisplayText(tip);
+        schedule(HOLD_MS, () => {
+          advanceTip();
+          tick();
+        });
+        return;
+      }
+
+      switch (phaseRef.current) {
+        case "holding":
+          phaseRef.current = "erasing";
+          schedule(HOLD_MS, eraseStep);
+          return;
+        case "erasing":
+          eraseStep();
+          return;
+        case "typing":
+          typeStep();
+          return;
+      }
+    };
+
+    const eraseStep = () => {
+      if (!visibleRef.current) return;
+      phaseRef.current = "erasing";
+      const pos = charPosRef.current;
+      if (pos <= 0) {
+        // Done erasing — advance and start typing the next tip on the
+        // next tick. We schedule one short delay so the empty caret
+        // gets a frame of visibility before typing kicks in.
+        advanceTip();
+        charPosRef.current = 0;
+        phaseRef.current = "typing";
+        setDisplayText("");
+        schedule(ERASE_PER_CHAR_MS, typeStep);
+        return;
+      }
+      const newPos = pos - 1;
+      charPosRef.current = newPos;
+      setDisplayText(TIPS[indexRef.current].slice(0, newPos));
+      schedule(ERASE_PER_CHAR_MS, eraseStep);
+    };
+
+    const typeStep = () => {
+      if (!visibleRef.current) return;
+      phaseRef.current = "typing";
+      const tip = TIPS[indexRef.current];
+      const pos = charPosRef.current;
+      if (pos >= tip.length) {
+        phaseRef.current = "holding";
+        setDisplayText(tip);
+        schedule(HOLD_MS, () => {
+          phaseRef.current = "erasing";
+          eraseStep();
+        });
+        return;
+      }
+      const newPos = pos + 1;
+      charPosRef.current = newPos;
+      setDisplayText(tip.slice(0, newPos));
+
+      // Cap the *total* typing time at MAX_TYPE_TOTAL_MS — for very
+      // long tips, dial the per-char delay down so the rotation
+      // doesn't stall waiting for the tip to finish.
+      const cap = MAX_TYPE_TOTAL_MS / Math.max(tip.length, 1);
+      const baseDelay = Math.min(TYPE_PER_CHAR_MS, cap);
+      const jitter =
+        (Math.random() * 2 - 1) * Math.min(TYPE_JITTER_MS, baseDelay * 0.5);
+      schedule(Math.max(baseDelay + jitter, MIN_CHAR_DELAY_MS), typeStep);
+    };
+
+    visibleRef.current =
+      typeof document === "undefined" || document.visibilityState === "visible";
+
+    if (visibleRef.current) tick();
+
+    const onVisibility = () => {
+      const next = document.visibilityState === "visible";
+      if (next === visibleRef.current) return;
+      visibleRef.current = next;
+      if (next) {
+        // Resume from wherever the state machine left off.
+        tick();
+      } else {
+        clear();
+      }
+    };
+
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", onVisibility);
+    }
+
+    return () => {
+      clear();
+      if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", onVisibility);
+      }
+    };
+  }, [mounted, reducedMotion]);
+
+  return (
+    <p
+      className={cn(
+        "text-xs text-muted-foreground mt-2 text-center",
+        className,
+      )}
+    >
+      <span aria-hidden="true">
+        💡 Tip: {displayText}
+        <span
+          aria-hidden="true"
+          className={cn(
+            "inline-block ml-0.5 align-baseline",
+            // Reduced motion: hold the caret static-visible. The blink is
+            // a `step-end` animation that some users find distracting,
+            // and the spec treats reduced-motion as "no caret blink".
+            reducedMotion ? "opacity-100" : "rotating-tip-caret",
+          )}
+        >
+          |
+        </span>
+      </span>
+      <span className="sr-only" aria-live="polite">
+        💡 Tip: {announcedTip}
+      </span>
+      <style>{`
+        @keyframes rotating-tip-caret-blink {
+          0%, 49% { opacity: 1; }
+          50%, 100% { opacity: 0; }
+        }
+        .rotating-tip-caret {
+          animation: rotating-tip-caret-blink 1s step-end infinite;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .rotating-tip-caret {
+            animation: none;
+            opacity: 1;
+          }
+        }
+      `}</style>
+    </p>
+  );
+}


### PR DESCRIPTION
## Summary

A pile of small `/game` UX improvements bundled together because they share the same surface and reflow each other.

### How To Play modal (first-run)

- The inline "How to Play" `Card` is gone. Replaced with a shadcn `Dialog` that auto-opens on a player's first visit.
- `localStorage` key `pokemon-palette-game-tutorial-seen` written *only* on dismiss, so a quick refresh re-shows it once.
- Skipped on the multiplayer tab (which renders its own component flow).
- Always re-openable via a new `HelpCircle` icon button (`aria-label="How to play"`) in the action row.

### Rotating tip (typewriter)

- New `src/components/rotating-tip.tsx` rendered beneath the Pokémon search input.
- Six curated tips (kept the existing multilingual search line, plus Pokédex number / type-based hint priming / color-palette nudge / Filters CTA / Esc-to-close).
- Type → hold → erase loop with a blinking caret (`|`).
- Random starting index per session, ~30ms/char with ±10ms jitter, total typing capped at ~2.5s for long tips, 5s hold, ~17ms/char erase.
- `prefers-reduced-motion: reduce` swaps to a static text update with a steady caret.
- Pauses on `document.visibilityState !== "visible"`.
- `aria-live="polite"` runs through a separate `sr-only` twin that updates once per rotation, so screen readers don't get the per-character chatter.

### Single-column layout

- The daily / unlimited grid (`grid-cols-1 lg:grid-cols-2 gap-6`) collapses to a single centered `max-w-xl` `flex flex-col gap-6` rail.
- Search + tip render inline at every breakpoint — dropped the mobile-only `<Dialog>` Search shim, `showSearchDialog` state, and `handleGuessWithDialog`.
- Removed the unused `Search` lucide icon import.

### Cleanup

- Removed the post-game "Want to keep playing? Try unlimited mode" CTA card — the result dialog already has a primary Play Again action and the mode tabs cover the manual switch.
- Gated the daily leaderboard button behind `mode === "daily" && status !== "playing"` so it only surfaces once today's run is finished.
- `GuessCard` swatch column: `w-10` → `w-16` so the flush-right color band reads as a real stripe at the new wider single-column layout.

## Test plan

- [ ] Clear `localStorage`, visit `/game` (daily mode): How To Play opens automatically. Dismiss it; refresh — it does *not* re-open. Click the help icon — it opens again.
- [ ] Switch to multiplayer mode on first visit — How To Play does not auto-open.
- [ ] Watch the rotating tip cycle. Type → hold → erase → next tip, with a blinking caret. Tab away; the rotation pauses. Re-enter; it resumes.
- [ ] Force `prefers-reduced-motion: reduce` in DevTools. Tips swap as static text, no per-character animation, caret is steady.
- [ ] Use a screen reader: each tip should be announced exactly once when it changes (not character-by-character).
- [ ] Layout: search + four guess slots stack vertically in a centered narrow column at every breakpoint. The flush-right swatch on each guess card looks like a real color band, not a thin sliver.
- [ ] Mobile: no `Search Pokémon` button / dialog — the input is inline.
- [ ] Daily mode mid-game: leaderboard button is hidden. Finish (win, lose, or give up) — leaderboard appears. Returning players who completed today see it on load.
- [ ] After the game ends in unlimited mode, no "Play Unlimited Mode" CTA card renders.
- [ ] `tsc --noEmit` and lint clean.
